### PR TITLE
Fixes NPE in Auto Configure steps

### DIFF
--- a/src/main/groovy/com/urbancode/air/plugin/cf/helper/CFHelper.groovy
+++ b/src/main/groovy/com/urbancode/air/plugin/cf/helper/CFHelper.groovy
@@ -39,7 +39,7 @@ class CFHelper {
         space = props['space']?.trim()
         cfHome = props['cfHome']?.trim()
         interpreter = props['interpreter']
-        envVars = gatherEnvironmentVariables(props['envVars'])
+        envVars = gatherEnvironmentVariables(props['envVars']?:"")
         envVars.each {
             helper.addEnvironmentVariable(it.key, it.value)
         }

--- a/src/main/zip/info.xml
+++ b/src/main/zip/info.xml
@@ -60,5 +60,8 @@
         CUPS and UUPS step now has optional username and password fields.
         CUPS and UUPS step's CF_HOME property now has a default value.
     </release-note>
+    <release-note plugin-version="23">
+        Fixes NullPointException when using the CF Auto-Configure step.
+    </release-note>
   </release-notes>
 </pluginInfo>

--- a/src/main/zip/plugin.xml
+++ b/src/main/zip/plugin.xml
@@ -7,7 +7,7 @@
 -->
 <plugin xmlns="http://www.urbancode.com/PluginXMLSchema_v1" xmlns:server="http://www.urbancode.com/PluginServerXMLSchema_v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <header>
-    <identifier id="com.urbancode.air.plugin.cloudfoundry" name="CloudFoundry" version="22"/>
+    <identifier id="com.urbancode.air.plugin.cloudfoundry" name="CloudFoundry" version="23"/>
     <description>
     The CloudFoundry plugin will use the CloudFoundry command line utility to interact with applications in a target CloudFoundry system.
     </description>

--- a/src/main/zip/upgrade.xml
+++ b/src/main/zip/upgrade.xml
@@ -559,4 +559,6 @@
             </migrate-properties>
         </migrate-command>
     </migrate>
+    <migrate to-version="23">
+    </migrate>
 </plugin-upgrade>


### PR DESCRIPTION
Auto Configure and Discovery steps do not have an envVars property
defined. This caused an NPE during all Auto Config and Discovery steps.