### PR TITLE
Added CF Command Path as hidden property

### DIFF
--- a/src/main/zip/info.xml
+++ b/src/main/zip/info.xml
@@ -61,7 +61,10 @@
         CUPS and UUPS step's CF_HOME property now has a default value.
     </release-note>
     <release-note plugin-version="23">
-        Fixes NullPointException when using the CF Auto-Configure step.
+        Fixes NullPointerException when using the CF Auto-Configure step.
+    </release-note>
+    <release-note plugin-version="24">
+        Added Cloud Foundry CLI Path property as a hidden variable to all automation steps.
     </release-note>
   </release-notes>
 </pluginInfo>

--- a/src/main/zip/plugin.xml
+++ b/src/main/zip/plugin.xml
@@ -7,7 +7,7 @@
 -->
 <plugin xmlns="http://www.urbancode.com/PluginXMLSchema_v1" xmlns:server="http://www.urbancode.com/PluginServerXMLSchema_v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <header>
-    <identifier id="com.urbancode.air.plugin.cloudfoundry" name="CloudFoundry" version="23"/>
+    <identifier id="com.urbancode.air.plugin.cloudfoundry" name="CloudFoundry" version="24"/>
     <description>
     The CloudFoundry plugin will use the CloudFoundry command line utility to interact with applications in a target CloudFoundry system.
     </description>
@@ -47,6 +47,10 @@
       <property name="cfHome">
         <property-ui type="textBox" label="CF_HOME" default-value="${p?:resource/cf.home}" description="Set the CF_HOME variable to explicitly define the location of the config.json file. A new CF_HOME will be used
             for each step if not specified."/>
+      </property>
+      <property name="commandPath">
+        <server:property-ui type="textBox" hidden="true" default-value="${p?:resource/cf.commandPath}" label="Cloud Foundry CLI Path"
+          description="The path to the cf command line script."/>
       </property>
       <property name="interpreter">
         <property-ui type="selectBox" hidden="true" label="Use Shell Interpreter"  default-value="${p&#63;:cf.interpreter}"
@@ -103,6 +107,10 @@
       <property name="cfHome">
         <property-ui type="textBox" label="CF_HOME" default-value="${p?:resource/cf.home}" description="Set the CF_HOME variable to explicitly define the location of the config.json file. A new CF_HOME will be used
             for each step if not specified."/>
+      </property>
+      <property name="commandPath">
+        <server:property-ui type="textBox" hidden="true" default-value="${p?:resource/cf.commandPath}" label="Cloud Foundry CLI Path"
+          description="The path to the cf command line script."/>
       </property>
       <property name="interpreter">
         <property-ui type="selectBox" hidden="true" label="Use Shell Interpreter"  default-value="${p&#63;:cf.interpreter}"
@@ -162,6 +170,10 @@
       <property name="cfHome">
         <property-ui type="textBox" label="CF_HOME" default-value="${p?:resource/cf.home}" description="Set the CF_HOME variable to explicitly define the location of the config.json file. A new CF_HOME will be used
             for each step if not specified."/>
+      </property>
+      <property name="commandPath">
+        <server:property-ui type="textBox" hidden="true" default-value="${p?:resource/cf.commandPath}" label="Cloud Foundry CLI Path"
+          description="The path to the cf command line script."/>
       </property>
       <property name="interpreter">
         <property-ui type="selectBox" hidden="true" label="Use Shell Interpreter"  default-value="${p&#63;:cf.interpreter}"
@@ -228,6 +240,10 @@
         <property-ui type="textBox" label="CF_HOME" default-value="${p?:resource/cf.home}" description="Set the CF_HOME variable to explicitly define the location of the config.json file. A new CF_HOME will be used
             for each step if not specified."/>
       </property>
+      <property name="commandPath">
+        <server:property-ui type="textBox" hidden="true" default-value="${p?:resource/cf.commandPath}" label="Cloud Foundry CLI Path"
+          description="The path to the cf command line script."/>
+      </property>
       <property name="interpreter">
         <property-ui type="selectBox" hidden="true" label="Use Shell Interpreter"  default-value="${p&#63;:cf.interpreter}"
                      description="Use a shell to interpret CF commands. This provides backward compatibility with the community plugin but does not escape special characters."/>
@@ -290,6 +306,10 @@
         <property-ui type="textBox" label="CF_HOME" default-value="${p?:resource/cf.home}" description="Set the CF_HOME variable to explicitly define the location of the config.json file. A new CF_HOME will be used
             for each step if not specified."/>
       </property>
+      <property name="commandPath">
+        <server:property-ui type="textBox" hidden="true" default-value="${p?:resource/cf.commandPath}" label="Cloud Foundry CLI Path"
+          description="The path to the cf command line script."/>
+      </property>
       <property name="interpreter">
         <property-ui type="selectBox" hidden="true" label="Use Shell Interpreter"  default-value="${p&#63;:cf.interpreter}"
                      description="Use a shell to interpret CF commands. This provides backward compatibility with the community plugin but does not escape special characters."/>
@@ -348,6 +368,10 @@
       <property name="cfHome">
         <property-ui type="textBox" label="CF_HOME" default-value="${p?:resource/cf.home}" description="Set the CF_HOME variable to explicitly define the location of the config.json file. A new CF_HOME will be used
             for each step if not specified."/>
+      </property>
+      <property name="commandPath">
+        <server:property-ui type="textBox" hidden="true" default-value="${p?:resource/cf.commandPath}" label="Cloud Foundry CLI Path"
+          description="The path to the cf command line script."/>
       </property>
       <property name="interpreter">
         <property-ui type="selectBox" hidden="true" label="Use Shell Interpreter"  default-value="${p&#63;:cf.interpreter}"
@@ -408,6 +432,10 @@
         <property-ui type="textBox" label="CF_HOME" default-value="${p?:resource/cf.home}" description="Set the CF_HOME variable to explicitly define the location of the config.json file. A new CF_HOME will be used
             for each step if not specified."/>
       </property>
+      <property name="commandPath">
+        <server:property-ui type="textBox" hidden="true" default-value="${p?:resource/cf.commandPath}" label="Cloud Foundry CLI Path"
+          description="The path to the cf command line script."/>
+      </property>
       <property name="interpreter">
         <property-ui type="selectBox" hidden="true" label="Use Shell Interpreter"  default-value="${p&#63;:cf.interpreter}"
                      description="Use a shell to interpret CF commands. This provides backward compatibility with the community plugin but does not escape special characters."/>
@@ -463,6 +491,10 @@
       <property name="cfHome">
         <property-ui type="textBox" label="CF_HOME" default-value="${p?:resource/cf.home}" description="Set the CF_HOME variable to explicitly define the location of the config.json file. A new CF_HOME will be used
             for each step if not specified."/>
+      </property>
+      <property name="commandPath">
+        <server:property-ui type="textBox" hidden="true" default-value="${p?:resource/cf.commandPath}" label="Cloud Foundry CLI Path"
+          description="The path to the cf command line script."/>
       </property>
       <property name="interpreter">
         <property-ui type="selectBox" hidden="true" label="Use Shell Interpreter"  default-value="${p&#63;:cf.interpreter}"
@@ -523,6 +555,10 @@
         <property-ui type="textBox" label="CF_HOME" default-value="${p?:resource/cf.home}" description="Set the CF_HOME variable to explicitly define the location of the config.json file. A new CF_HOME will be used
             for each step if not specified."/>
       </property>
+      <property name="commandPath">
+        <server:property-ui type="textBox" hidden="true" default-value="${p?:resource/cf.commandPath}" label="Cloud Foundry CLI Path"
+          description="The path to the cf command line script."/>
+      </property>
       <property name="interpreter">
         <property-ui type="selectBox" hidden="true" label="Use Shell Interpreter"  default-value="${p&#63;:cf.interpreter}"
                      description="Use a shell to interpret CF commands. This provides backward compatibility with the community plugin but does not escape special characters."/>
@@ -578,6 +614,10 @@
       <property name="cfHome">
         <property-ui type="textBox" label="CF_HOME" default-value="${p?:resource/cf.home}" description="Set the CF_HOME variable to explicitly define the location of the config.json file. A new CF_HOME will be used
             for each step if not specified."/>
+      </property>
+      <property name="commandPath">
+        <server:property-ui type="textBox" hidden="true" default-value="${p?:resource/cf.commandPath}" label="Cloud Foundry CLI Path"
+          description="The path to the cf command line script."/>
       </property>
       <property name="interpreter">
         <property-ui type="selectBox" hidden="true" label="Use Shell Interpreter"  default-value="${p&#63;:cf.interpreter}"
@@ -638,6 +678,10 @@
         <property-ui type="textBox" label="CF_HOME" default-value="${p?:resource/cf.home}" description="Set the CF_HOME variable to explicitly define the location of the config.json file. A new CF_HOME will be used
             for each step if not specified."/>
       </property>
+      <property name="commandPath">
+        <server:property-ui type="textBox" hidden="true" default-value="${p?:resource/cf.commandPath}" label="Cloud Foundry CLI Path"
+          description="The path to the cf command line script."/>
+      </property>
       <property name="interpreter">
         <property-ui type="selectBox" hidden="true" label="Use Shell Interpreter"  default-value="${p&#63;:cf.interpreter}"
                      description="Use a shell to interpret CF commands. This provides backward compatibility with the community plugin but does not escape special characters."/>
@@ -697,6 +741,10 @@
         <property-ui type="textBox" label="CF_HOME" default-value="${p?:resource/cf.home}" description="Set the CF_HOME variable to explicitly define the location of the config.json file. A new CF_HOME will be used
             for each step if not specified."/>
       </property>
+      <property name="commandPath">
+        <server:property-ui type="textBox" hidden="true" default-value="${p?:resource/cf.commandPath}" label="Cloud Foundry CLI Path"
+          description="The path to the cf command line script."/>
+      </property>
       <property name="interpreter">
         <property-ui type="selectBox" hidden="true" label="Use Shell Interpreter"  default-value="${p&#63;:cf.interpreter}"
                      description="Use a shell to interpret CF commands. This provides backward compatibility with the community plugin but does not escape special characters."/>
@@ -755,6 +803,10 @@
       <property name="cfHome">
         <property-ui type="textBox" label="CF_HOME" default-value="${p?:resource/cf.home}" description="Set the CF_HOME variable to explicitly define the location of the config.json file. A new CF_HOME will be used
             for each step if not specified."/>
+      </property>
+      <property name="commandPath">
+        <server:property-ui type="textBox" hidden="true" default-value="${p?:resource/cf.commandPath}" label="Cloud Foundry CLI Path"
+          description="The path to the cf command line script."/>
       </property>
       <property name="interpreter">
         <property-ui type="selectBox" hidden="true" label="Use Shell Interpreter"  default-value="${p&#63;:cf.interpreter}"
@@ -817,6 +869,10 @@
       <property name="cfHome">
         <property-ui type="textBox" label="CF_HOME" default-value="${p?:resource/cf.home}" description="Set the CF_HOME variable to explicitly define the location of the config.json file. A new CF_HOME will be used
             for each step if not specified."/>
+      </property>
+      <property name="commandPath">
+        <server:property-ui type="textBox" hidden="true" default-value="${p?:resource/cf.commandPath}" label="Cloud Foundry CLI Path"
+          description="The path to the cf command line script."/>
       </property>
       <property name="interpreter">
         <property-ui type="selectBox" hidden="true" label="Use Shell Interpreter"  default-value="${p&#63;:cf.interpreter}"
@@ -919,6 +975,10 @@
         <property-ui type="textBox" label="CF_HOME" default-value="${p?:resource/cf.home}" description="Set the CF_HOME variable to explicitly define the location of the config.json file. A new CF_HOME will be used
             for each step if not specified."/>
       </property>
+      <property name="commandPath">
+        <server:property-ui type="textBox" hidden="true" default-value="${p?:resource/cf.commandPath}" label="Cloud Foundry CLI Path"
+          description="The path to the cf command line script."/>
+      </property>
       <property name="interpreter">
         <property-ui type="selectBox" hidden="true" label="Use Shell Interpreter"  default-value="${p&#63;:cf.interpreter}"
                      description="Use a shell to interpret CF commands. This provides backward compatibility with the community plugin but does not escape special characters."/>
@@ -974,6 +1034,10 @@
       <property name="cfHome">
         <property-ui type="textBox" label="CF_HOME" default-value="${p?:resource/cf.home}" description="Set the CF_HOME variable to explicitly define the location of the config.json file. A new CF_HOME will be used
             for each step if not specified."/>
+      </property>
+      <property name="commandPath">
+        <server:property-ui type="textBox" hidden="true" default-value="${p?:resource/cf.commandPath}" label="Cloud Foundry CLI Path"
+          description="The path to the cf command line script."/>
       </property>
       <property name="interpreter">
         <property-ui type="selectBox" hidden="true" label="Use Shell Interpreter"  default-value="${p&#63;:cf.interpreter}"
@@ -1031,6 +1095,10 @@
         <property-ui type="textBox" label="CF_HOME" default-value="${p?:resource/cf.home}" description="Set the CF_HOME variable to explicitly define the location of the config.json file. A new CF_HOME will be used
             for each step if not specified."/>
       </property>
+      <property name="commandPath">
+        <server:property-ui type="textBox" hidden="true" default-value="${p?:resource/cf.commandPath}" label="Cloud Foundry CLI Path"
+          description="The path to the cf command line script."/>
+      </property>
       <property name="interpreter">
         <property-ui type="selectBox" hidden="true" label="Use Shell Interpreter"  default-value="${p&#63;:cf.interpreter}"
                      description="Use a shell to interpret CF commands. This provides backward compatibility with the community plugin but does not escape special characters."/>
@@ -1086,6 +1154,10 @@
       <property name="cfHome">
         <property-ui type="textBox" label="CF_HOME" default-value="${p?:resource/cf.home}" description="Set the CF_HOME variable to explicitly define the location of the config.json file. A new CF_HOME will be used
             for each step if not specified."/>
+      </property>
+      <property name="commandPath">
+        <server:property-ui type="textBox" hidden="true" default-value="${p?:resource/cf.commandPath}" label="Cloud Foundry CLI Path"
+          description="The path to the cf command line script."/>
       </property>
       <property name="interpreter">
         <property-ui type="selectBox" hidden="true" label="Use Shell Interpreter"  default-value="${p&#63;:cf.interpreter}"
@@ -1145,6 +1217,10 @@
       <property name="cfHome">
         <property-ui type="textBox" label="CF_HOME" default-value="${p?:resource/cf.home}" description="Set the CF_HOME variable to explicitly define the location of the config.json file. A new CF_HOME will be used
             for each step if not specified."/>
+      </property>
+      <property name="commandPath">
+        <server:property-ui type="textBox" hidden="true" default-value="${p?:resource/cf.commandPath}" label="Cloud Foundry CLI Path"
+          description="The path to the cf command line script."/>
       </property>
       <property name="interpreter">
         <property-ui type="selectBox" hidden="true" label="Use Shell Interpreter" default-value="${p&#63;:cf.interpreter}"
@@ -1207,6 +1283,10 @@
       <property name="cfHome">
         <property-ui type="textBox" label="CF_HOME" default-value="${p?:resource/cf.home}" description="Set the CF_HOME variable to explicitly define the location of the config.json file. A new CF_HOME will be used
             for each step if not specified."/>
+      </property>
+      <property name="commandPath">
+        <server:property-ui type="textBox" hidden="true" default-value="${p?:resource/cf.commandPath}" label="Cloud Foundry CLI Path"
+          description="The path to the cf command line script."/>
       </property>
       <property name="interpreter">
         <property-ui type="selectBox" hidden="true" label="Use Shell Interpreter" default-value="${p&#63;:cf.interpreter}"

--- a/src/main/zip/upgrade.xml
+++ b/src/main/zip/upgrade.xml
@@ -561,4 +561,106 @@
     </migrate>
     <migrate to-version="23">
     </migrate>
+    <migrate to-version="24">
+        <migrate-command name="Push Application">
+            <migrate-properties>
+                <migrate-property name="commandPath" default="${p?:resource/cf.commandPath}" />
+            </migrate-properties>
+        </migrate-command>
+        <migrate-command name="Execute CF Script">
+            <migrate-properties>
+                <migrate-property name="commandPath" default="${p?:resource/cf.commandPath}" />
+            </migrate-properties>
+        </migrate-command>
+        <migrate-command name="Execute CF bash file">
+            <migrate-properties>
+                <migrate-property name="commandPath" default="${p?:resource/cf.commandPath}" />
+            </migrate-properties>
+        </migrate-command>
+        <migrate-command name="Create Service">
+            <migrate-properties>
+                <migrate-property name="commandPath" default="${p?:resource/cf.commandPath}" />
+            </migrate-properties>
+        </migrate-command>
+        <migrate-command name="Create or Update User-Provided Service">
+            <migrate-properties>
+                <migrate-property name="commandPath" default="${p?:resource/cf.commandPath}" />
+            </migrate-properties>
+        </migrate-command>
+        <migrate-command name="Delete Service">
+            <migrate-properties>
+                <migrate-property name="commandPath" default="${p?:resource/cf.commandPath}" />
+            </migrate-properties>
+        </migrate-command>
+        <migrate-command name="Bind Service">
+            <migrate-properties>
+                <migrate-property name="commandPath" default="${p?:resource/cf.commandPath}" />
+            </migrate-properties>
+        </migrate-command>
+        <migrate-command name="Unbind Service">
+            <migrate-properties>
+                <migrate-property name="commandPath" default="${p?:resource/cf.commandPath}" />
+            </migrate-properties>
+        </migrate-command>
+        <migrate-command name="Map Route">
+            <migrate-properties>
+                <migrate-property name="commandPath" default="${p?:resource/cf.commandPath}" />
+            </migrate-properties>
+        </migrate-command>
+        <migrate-command name="Unmap Route">
+            <migrate-properties>
+                <migrate-property name="commandPath" default="${p?:resource/cf.commandPath}" />
+            </migrate-properties>
+        </migrate-command>
+        <migrate-command name="Delete App">
+            <migrate-properties>
+                <migrate-property name="commandPath" default="${p?:resource/cf.commandPath}" />
+            </migrate-properties>
+        </migrate-command>
+        <migrate-command name="Start App">
+            <migrate-properties>
+                <migrate-property name="commandPath" default="${p?:resource/cf.commandPath}" />
+            </migrate-properties>
+        </migrate-command>
+        <migrate-command name="Stop App">
+            <migrate-properties>
+                <migrate-property name="commandPath" default="${p?:resource/cf.commandPath}" />
+            </migrate-properties>
+        </migrate-command>
+        <migrate-command name="Restart App">
+            <migrate-properties>
+                <migrate-property name="commandPath" default="${p?:resource/cf.commandPath}" />
+            </migrate-properties>
+        </migrate-command>
+        <migrate-command name="Create Route">
+            <migrate-properties>
+                <migrate-property name="commandPath" default="${p?:resource/cf.commandPath}" />
+            </migrate-properties>
+            </migrate-command>
+        <migrate-command name="Delete Route">
+            <migrate-properties>
+                <migrate-property name="commandPath" default="${p?:resource/cf.commandPath}" />
+            </migrate-properties>
+        </migrate-command>
+        <migrate-command name="Create Domain">
+            <migrate-properties>
+                <migrate-property name="commandPath" default="${p?:resource/cf.commandPath}" />
+            </migrate-properties>
+        </migrate-command>
+        <migrate-command name="Delete Domain">
+            <migrate-properties>
+                <migrate-property name="commandPath" default="${p?:resource/cf.commandPath}" />
+            </migrate-properties>
+        </migrate-command>
+        <migrate-command name="Create Subdomain">
+            <migrate-properties>
+                <migrate-property name="commandPath" default="${p?:resource/cf.commandPath}" />
+            </migrate-properties>
+        </migrate-command>
+        <migrate-command name="Delete Subdomain">
+            <migrate-properties>
+                <migrate-property name="commandPath" default="${p?:resource/cf.commandPath}" />
+            </migrate-properties>
+        </migrate-command>
+    </migrate>
 </plugin-upgrade>


### PR DESCRIPTION
Every step now has a hidden property called `Cloud Foundry CLI Path` where you can specify the `cf` executable file.
The Auto Discovery and Configure steps already had their own `Cloud Foundry CLI Path` property.

The default values are the same: `${p?:resource/cf.commandPath}`. If left empty or undefined, it will default to `cf`.